### PR TITLE
Use python27 in prepare-benchmark.sh and run-query.sh

### DIFF
--- a/runner/prepare-benchmark.sh
+++ b/runner/prepare-benchmark.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 cd "`dirname $0`"
-PYTHONPATH="./deps/:$PYTHONPATH" python ./prepare_benchmark.py $@
+PYTHONPATH="./deps/:$PYTHONPATH" python27 ./prepare_benchmark.py $@

--- a/runner/run-query.sh
+++ b/runner/run-query.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 cd "`dirname $0`"
-PYTHONPATH="./deps/:$PYTHONPATH" python ./run_query.py $@
+PYTHONPATH="./deps/:$PYTHONPATH" python27 ./run_query.py $@


### PR DESCRIPTION
These scripts must be executed using Python 2.7, so this commit changes
them to directly use the python27 command. This enables these scripts to
be used on machines where Python 2.7 is not the default version of
Python.
