### PR TITLE
Change python27 to python2.7

### DIFF
--- a/runner/prepare-benchmark.sh
+++ b/runner/prepare-benchmark.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 cd "`dirname $0`"
-PYTHONPATH="./deps/:$PYTHONPATH" python27 ./prepare_benchmark.py $@
+PYTHONPATH="./deps/:$PYTHONPATH" python2.7 ./prepare_benchmark.py $@

--- a/runner/run-query.sh
+++ b/runner/run-query.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 cd "`dirname $0`"
-PYTHONPATH="./deps/:$PYTHONPATH" python27 ./run_query.py $@
+PYTHONPATH="./deps/:$PYTHONPATH" python2.7 ./run_query.py $@


### PR DESCRIPTION
This commit changes prepare-benchmark.sh and run-query.sh to use the
python2.7 command instead of the python27 command in order for these
scripts to be compatible with Macs as well as the EC2 machines.
